### PR TITLE
fix: add proxy timeout to 3600 seconds

### DIFF
--- a/pkg/serviceproxy/v1alpha1/proxy.go
+++ b/pkg/serviceproxy/v1alpha1/proxy.go
@@ -272,7 +272,7 @@ func (p *Proxy) ProxyLegacyAPIV2(ctx context.Context,
 			DisableCompression: true,
 		}).SetDoNotParseResponse(true)
 
-		proxyReq := client.SetTimeout(360*time.Second).R().
+		proxyReq := client.SetTimeout(3600*time.Second).R().
 			SetQueryParamsFromValues(req.Request.URL.Query()).
 			SetHeaderMultiValues(req.Request.Header).
 			SetHeader(apiv1alpha1.BackendTokenHeader, constants.Nonce).


### PR DESCRIPTION
fix: add proxy timeout to 3600 seconds for some long time situation, such model download